### PR TITLE
feat(build): firefox manifest variant + per-browser build scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
             - run: npm ci
             - run: npm run lint
             - run: npm run test:coverage
-            - run: npm run build
+            - run: npm run build:chrome
+            - run: npm run build:firefox
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v4
               with:

--- a/.github/workflows/release-asset.yml
+++ b/.github/workflows/release-asset.yml
@@ -18,15 +18,21 @@ jobs:
                   node-version: '22'
                   cache: 'npm'
             - run: npm ci
-            - run: npm run build
-            - name: Package dist as zip
+            - run: npm run build:chrome
+            - run: npm run build:firefox
+            - name: Package chrome dist as zip
               run: |
                   cd dist
                   zip -r "../linkstash-extension-${{ github.event.release.tag_name }}.zip" .
-            - name: Upload asset to release
+            - name: Package firefox dist as zip
+              run: |
+                  cd dist-firefox
+                  zip -r "../linkstash-extension-firefox-${{ github.event.release.tag_name }}.zip" .
+            - name: Upload assets to release
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   gh release upload "${{ github.event.release.tag_name }}" \
                       "linkstash-extension-${{ github.event.release.tag_name }}.zip" \
+                      "linkstash-extension-firefox-${{ github.event.release.tag_name }}.zip" \
                       --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+dist-firefox/
 .dist/
 .cache/
 .parcel-cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Firefox manifest variant via `BROWSER=firefox` build (closes #16):
+  `npm run build:firefox` emits `dist-firefox/` with a
+  `browser_specific_settings.gecko` block; `npm run package:firefox`
+  zips it for AMO submission. Edge consumes the unchanged Chrome zip.
+
 ## [0.1.0] - 2026-05-02
 
 Initial public release.

--- a/README.md
+++ b/README.md
@@ -85,8 +85,10 @@ The detailed implementation plan lives in
 
 ```bash
 npm install
-npm run dev       # Vite dev server with extension HMR
-npm run build     # production build to dist/
+npm run dev               # Vite dev server with extension HMR
+npm run build             # production chrome build to dist/
+npm run build:firefox     # firefox build to dist-firefox/
+npm run build:all         # both
 npm run lint
 npm run lint:fix
 npm run test

--- a/package.json
+++ b/package.json
@@ -7,14 +7,20 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "npm run build:chrome",
+    "build:chrome": "tsc -b && BROWSER=chrome vite build",
+    "build:firefox": "tsc -b && BROWSER=firefox vite build",
+    "build:all": "npm run build:chrome && npm run build:firefox",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "package": "npm run build && node scripts/package.mjs"
+    "package": "npm run package:chrome",
+    "package:chrome": "npm run build:chrome && node scripts/package.mjs --browser=chrome",
+    "package:firefox": "npm run build:firefox && node scripts/package.mjs --browser=firefox",
+    "package:all": "npm run package:chrome && npm run package:firefox"
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.0.0",

--- a/scripts/manifest-overlay.test.ts
+++ b/scripts/manifest-overlay.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import manifest from '../manifest.json';
+import {
+  applyBrowserOverlay,
+  FIREFOX_GECKO_ID,
+  FIREFOX_MIN_VERSION,
+  isBrowser,
+  outDirFor,
+} from './manifest-overlay';
+
+describe('applyBrowserOverlay', () => {
+  it('returns the chrome manifest unchanged in shape', () => {
+    const out = applyBrowserOverlay(manifest, 'chrome');
+    expect(out).not.toHaveProperty('browser_specific_settings');
+    expect(out.minimum_chrome_version).toBe(manifest.minimum_chrome_version);
+    expect(out.manifest_version).toBe(3);
+  });
+
+  it('adds browser_specific_settings.gecko for firefox', () => {
+    const out = applyBrowserOverlay(manifest, 'firefox') as Record<string, unknown> & {
+      browser_specific_settings: { gecko: { id: string; strict_min_version: string } };
+    };
+    expect(out.browser_specific_settings.gecko).toEqual({
+      id: FIREFOX_GECKO_ID,
+      strict_min_version: FIREFOX_MIN_VERSION,
+    });
+  });
+
+  it('strips minimum_chrome_version from the firefox manifest', () => {
+    const out = applyBrowserOverlay(manifest, 'firefox');
+    expect(out).not.toHaveProperty('minimum_chrome_version');
+  });
+
+  it('does not mutate the input', () => {
+    const before = JSON.stringify(manifest);
+    applyBrowserOverlay(manifest, 'firefox');
+    expect(JSON.stringify(manifest)).toBe(before);
+  });
+});
+
+describe('isBrowser', () => {
+  it('accepts chrome and firefox', () => {
+    expect(isBrowser('chrome')).toBe(true);
+    expect(isBrowser('firefox')).toBe(true);
+  });
+
+  it('rejects everything else', () => {
+    expect(isBrowser('safari')).toBe(false);
+    expect(isBrowser('')).toBe(false);
+    expect(isBrowser(undefined)).toBe(false);
+  });
+});
+
+describe('outDirFor', () => {
+  it('routes chrome to dist/ and firefox to dist-firefox/', () => {
+    expect(outDirFor('chrome')).toBe('dist');
+    expect(outDirFor('firefox')).toBe('dist-firefox');
+  });
+});

--- a/scripts/manifest-overlay.ts
+++ b/scripts/manifest-overlay.ts
@@ -1,0 +1,35 @@
+export type Browser = 'chrome' | 'firefox';
+
+export const FIREFOX_GECKO_ID = 'linkstash@apermo.de';
+export const FIREFOX_MIN_VERSION = '121.0';
+
+export function isBrowser(value: string | undefined): value is Browser {
+  return value === 'chrome' || value === 'firefox';
+}
+
+export function applyBrowserOverlay(
+  base: Record<string, unknown>,
+  browser: Browser,
+): Record<string, unknown> {
+  if (browser === 'chrome') {
+    return { ...base };
+  }
+
+  const { minimum_chrome_version: _drop, ...rest } = base as {
+    minimum_chrome_version?: string;
+  } & Record<string, unknown>;
+
+  return {
+    ...rest,
+    browser_specific_settings: {
+      gecko: {
+        id: FIREFOX_GECKO_ID,
+        strict_min_version: FIREFOX_MIN_VERSION,
+      },
+    },
+  };
+}
+
+export function outDirFor(browser: Browser): string {
+  return browser === 'firefox' ? 'dist-firefox' : 'dist';
+}

--- a/scripts/manifest-overlay.ts
+++ b/scripts/manifest-overlay.ts
@@ -1,6 +1,6 @@
 export type Browser = 'chrome' | 'firefox';
 
-export const FIREFOX_GECKO_ID = 'linkstash@apermo.de';
+export const FIREFOX_GECKO_ID = 'linkstash-extension@apermo.github.io';
 export const FIREFOX_MIN_VERSION = '121.0';
 
 export function isBrowser(value: string | undefined): value is Browser {

--- a/scripts/package.mjs
+++ b/scripts/package.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { createWriteStream, existsSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -7,17 +7,26 @@ import { spawn } from 'node:child_process';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '..');
-const distDir = join(repoRoot, 'dist');
 const releasesDir = join(repoRoot, 'releases');
 
+const browserArg = process.argv.find((a) => a.startsWith('--browser='));
+const browser = browserArg ? browserArg.split('=')[1] : 'chrome';
+if (browser !== 'chrome' && browser !== 'firefox') {
+  console.error(`--browser must be "chrome" or "firefox" (got "${browser}")`);
+  process.exit(1);
+}
+
+const distDir = join(repoRoot, browser === 'firefox' ? 'dist-firefox' : 'dist');
+
 if (!existsSync(distDir) || !statSync(distDir).isDirectory()) {
-  console.error('dist/ does not exist — run `npm run build` first.');
+  console.error(`${distDir} does not exist — run \`npm run build:${browser}\` first.`);
   process.exit(1);
 }
 
 const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'));
 const version = pkg.version;
-const zipName = `linkstash-extension-v${version}.zip`;
+const suffix = browser === 'firefox' ? '-firefox' : '';
+const zipName = `linkstash-extension${suffix}-v${version}.zip`;
 const zipPath = join(releasesDir, zipName);
 
 await mkdir(releasesDir, { recursive: true });
@@ -36,5 +45,6 @@ await new Promise((resolvePromise, rejectPromise) => {
 });
 
 const size = (statSync(zipPath).size / 1024).toFixed(1);
+const target = browser === 'firefox' ? 'AMO (addons.mozilla.org)' : 'the Chrome Web Store dev console';
 console.log(`\n✓ Packaged ${zipName} (${size} KB) → ${zipPath}`);
-console.log('  Upload this to the Chrome Web Store dev console.');
+console.log(`  Upload this to ${target}.`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,6 @@
     "useDefineForClassFields": true,
     "noEmit": true
   },
-  "include": ["src", "vite.config.ts", "vitest.config.ts", "eslint.config.js"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src", "scripts/**/*.ts", "vite.config.ts", "vitest.config.ts", "eslint.config.js"],
+  "exclude": ["node_modules", "dist", "dist-firefox"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,18 +2,27 @@ import { defineConfig } from 'vite';
 import { crx } from '@crxjs/vite-plugin';
 import manifest from './manifest.json' with { type: 'json' };
 import pkg from './package.json' with { type: 'json' };
+import { applyBrowserOverlay, isBrowser, outDirFor } from './scripts/manifest-overlay';
+
+const requested = process.env.BROWSER ?? 'chrome';
+if (!isBrowser(requested)) {
+  throw new Error(`BROWSER must be "chrome" or "firefox" (got "${requested}")`);
+}
+const browser = requested;
 
 // Single source of truth for the version is package.json — keeps the dev
 // console listing, the GitHub release tag, and the manifest in lockstep.
-const versioned = { ...manifest, version: pkg.version };
+const versioned = applyBrowserOverlay({ ...manifest, version: pkg.version }, browser);
 
 export default defineConfig({
-  plugins: [crx({ manifest: versioned })],
+  // CRXJS infers the manifest type from the imported JSON; the overlay returns
+  // a plain Record, so cast at the boundary rather than threading generics.
+  plugins: [crx({ manifest: versioned as typeof manifest })],
   build: {
-    outDir: 'dist',
+    outDir: outDirFor(browser),
     emptyOutDir: true,
     sourcemap: true,
-    target: 'chrome116',
+    target: browser === 'firefox' ? 'firefox121' : 'chrome116',
   },
   server: {
     port: 5173,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'happy-dom',
-    include: ['src/**/*.{test,spec}.ts'],
+    include: ['src/**/*.{test,spec}.ts', 'scripts/**/*.{test,spec}.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],


### PR DESCRIPTION
## Summary

- `BROWSER=chrome|firefox` switches the vite output dir and applies a manifest overlay (`scripts/manifest-overlay.ts`).
- Firefox manifest gets `browser_specific_settings.gecko` (id `linkstash@apermo.de`, `strict_min_version 121.0`) and has `minimum_chrome_version` stripped.
- New scripts: `build:chrome`, `build:firefox`, `build:all`, `package:chrome`, `package:firefox`, `package:all`.
- Firefox build lands in `dist-firefox/`; package emits `linkstash-extension-firefox-vX.Y.Z.zip` for AMO.
- CI builds both targets so manifest-overlay regressions are caught on PRs.
- Release workflow uploads both zips as release assets.

Edge consumes the unmodified Chrome zip — no separate variant needed.

> [!NOTE]
> The gecko ID `linkstash@apermo.de` is a placeholder. If AMO assigns a different ID after first submission, update `FIREFOX_GECKO_ID` in `scripts/manifest-overlay.ts`.

Closes #16.

## Test plan

- [ ] `npm run build:chrome` produces `dist/manifest.json` with `minimum_chrome_version` and **no** `browser_specific_settings`.
- [ ] `npm run build:firefox` produces `dist-firefox/manifest.json` **without** `minimum_chrome_version` and **with** `browser_specific_settings.gecko`.
- [ ] `npm test` — overlay tests pass.
- [ ] Load `dist/` unpacked in Chrome → save flow works as before.
- [ ] Load `dist-firefox/` as temporary add-on in Firefox 121+ (`about:debugging` → Load Temporary Add-on → pick `manifest.json`) → save flow works.
- [ ] `npm run package:firefox` produces a zip uploadable to AMO.