### PR TITLE
docs(store): swap notifications justification for scripting

### DIFF
--- a/docs/store/listing.md
+++ b/docs/store/listing.md
@@ -62,7 +62,9 @@ PERMISSIONS
 • activeTab — to read the current tab's URL and title when you
   click the action.
 • contextMenus — to register the right-click save entries.
-• notifications — to confirm context-menu saves.
+• scripting — to show a brief in-page confirmation pill after a
+  save. The pill is a fixed-position DOM element that auto-dismisses
+  after ~2.6 s; nothing else on the page is touched.
 • Host access (granted at runtime) — to talk to the LinkStash host
   you configure. The extension asks Chrome for the specific origin
   you enter; you can deny.
@@ -100,10 +102,17 @@ verbatim.
 > and "Save page to LinkStash" on pages — so the user can bookmark
 > without opening the popup.
 
-### `notifications`
+### `scripting`
 
-> Shows a success or error toast after a context-menu save so the
-> user gets confirmation without having to open the popup.
+> Used solely to inject a transient confirmation pill (a 2.6-second
+> toast at the top of the active tab) after the user saves a
+> bookmark. The injected function only manipulates the DOM — it
+> creates a fixed-position element, animates it in and out, and
+> removes itself. It does not read page content, intercept page
+> scripts, or send anything from the page anywhere. Runs in the
+> default isolated world. Source: `src/background/toast.ts`
+> (`renderToast` is the injected function; `chrome.scripting.executeScript`
+> is called from `showToastIn` only on save success/failure).
 
 ### `host_permissions` (declared as `optional_host_permissions: https://*/*`)
 


### PR DESCRIPTION
## Why

CWS dev console flagged the v0.1.1 upload because it requires a
privacy-tab justification for the `scripting` permission, which
landed in the manifest in PR #23 (replacing `chrome.notifications`
with an injected in-page toast). The store listing copy in
`docs/store/listing.md` was still describing the old permission
set, so the verbatim text to paste into the form wasn't correct.

## What

- Swap the `notifications` line in the user-facing `PERMISSIONS`
  bullet list for a `scripting` line.
- Replace the `### \`notifications\`` justification block with a
  `### \`scripting\`` block that describes:
  - what the permission is used for (transient in-page
    confirmation pill on save),
  - what the injected function does and doesn't do
    (DOM-only, fixed-position element, auto-dismiss; no page
    content read, no exfiltration),
  - which world it runs in (default isolated),
  - source pointer (`src/background/toast.ts`).

The text is the verbatim string to paste into the dev console's
privacy tab.

## Test plan

- [x] `npm run build` clean (no code touched, just docs).
- [ ] Pasted into the CWS dev console privacy tab and submitted
      with the v0.1.1 upload.