### PR TITLE
ci: bump actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
         name: Lint, test, build
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v5
+            - uses: actions/setup-node@v5
               with:
                   node-version: '22'
                   cache: 'npm'
@@ -36,7 +36,7 @@ jobs:
                   fail_ci_if_error: false
                   token: ${{ secrets.CODECOV_TOKEN }}
                   slug: ${{ github.repository }}
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@v5
               with:
                   name: dist
                   path: dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,11 +77,11 @@ jobs:
                   done
                   echo "Release $TAG never appeared after 5 minutes — bailing." >&2
                   exit 1
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               if: ${{ steps.tag.outputs.prerelease != 'true' }}
               with:
                   ref: ${{ steps.tag.outputs.name }}
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               if: ${{ steps.tag.outputs.prerelease != 'true' }}
               with:
                   node-version: '22'

--- a/.github/workflows/release-asset.yml
+++ b/.github/workflows/release-asset.yml
@@ -29,10 +29,10 @@ jobs:
                   else
                       echo "name=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
                   fi
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               with:
                   ref: ${{ steps.tag.outputs.name }}
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
                   node-version: '22'
                   cache: 'npm'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump GitHub Actions off the deprecated Node 20 runtime: `actions/checkout`
+  v4→v5, `actions/setup-node` v4→v5, `actions/upload-artifact` v4→v5. GitHub
+  forces JavaScript actions onto Node 24 starting 2026-06-16.
+
 ## [0.1.1] - 2026-05-03
 
 ### Added


### PR DESCRIPTION
## Background

GitHub forces JavaScript actions off the deprecated Node 20 runtime starting **2026-06-16**, with full removal on 2026-09-16.

## Changes

- `actions/checkout` v4→v5
- `actions/setup-node` v4→v5
- `actions/upload-artifact` v4→v5

Each target is the first major of that action on the Node 24 runtime. Documented under `## [Unreleased]` so it ships without forcing a release.

Closes #33